### PR TITLE
[FIX] Added compatibility check on country, language for pycountry

### DIFF
--- a/teamleader/__init__.py
+++ b/teamleader/__init__.py
@@ -1,2 +1,2 @@
 __prog__ = 'python-teamleader'
-__version__ = u'1.0.2'
+__version__ = u'1.0.3'

--- a/teamleader/__init__.py
+++ b/teamleader/__init__.py
@@ -1,2 +1,2 @@
 __prog__ = 'python-teamleader'
-__version__ = u'1.0.1'
+__version__ = u'1.0.2'

--- a/teamleader/__init__.py
+++ b/teamleader/__init__.py
@@ -1,2 +1,2 @@
 __prog__ = 'python-teamleader'
-__version__ = u'1.0.3'
+__version__ = u'1.0.1.4'

--- a/teamleader/api.py
+++ b/teamleader/api.py
@@ -695,3 +695,81 @@ class Teamleader(object):
 
     def get_creditnote(self):
         pass
+
+    # Deals
+    def get_deal(self, deal_id):
+        """Fetching deal information.
+
+        Args:
+            deal_id: integer: ID of the deal
+
+        Returns:
+            Dictionary with info about the deal.
+        """
+
+        return self._request('getDeal', {
+            'deal_id': deal_id,
+        })
+
+    def get_company_deals(self, company_id):
+        """Searching all deals related to a company.
+
+        Args:
+            company_id: integer: ID of the company
+
+        Returns:
+            Dictionary with company deals.
+        """
+
+        return self._request('getDealsByContactOrCompany', {
+            'contact_or_company': 'company',
+            'contact_or_company_id': company_id,
+        })
+
+    def get_contact_deals(self, contact_id):
+        """Searching all deals related to a contact.
+
+        Args:
+            contact_id: integer: ID of the contact
+
+        Returns:
+            Dictionary with contact deals.
+        """
+
+        return self._request('getDealsByContactOrCompany', {
+            'contact_or_company': 'contact',
+            'contact_or_company_id': contact_id,
+        })
+
+    def get_all_deal_phase_changes(self, date_from, date_to=datetime.date.today()):
+        """Fetching deal phase changes for all deals in a certain time range.
+
+        Args:
+            date_from: date (dd/mm/yyyy): the start date of the period
+            date_to: date (dd/mm/yyyy): the end date of the period
+
+        Returns:
+            Dictionary containing all phase changes that occurred in this period.
+        """
+        if date_from is not None and type(date_from) != datetime.date:
+            raise InvalidInputError("Invalid contents of argument date_from.")
+
+        if date_to is not None and type(date_to) != datetime.date:
+            raise InvalidInputError("Invalid contents of argument date_to.")
+
+        return self._request('getAllDealPhaseChanges', {
+            'date_from': date_from.strftime('%d/%m/%Y'),
+            'date_to': date_to.strftime('%d/%m/%Y'),
+        })
+
+    def get_deal_phases(self):
+        """Fetching all deal phases.
+
+        Args:
+            none
+
+        Returns:
+            Dictionary with deal phases.
+        """
+
+        return self._request('getDealPhases')

--- a/teamleader/api.py
+++ b/teamleader/api.py
@@ -7,6 +7,7 @@ import logging
 import pycountry
 import datetime
 import time
+import pkg_resources
 
 from teamleader.exceptions import *
 
@@ -56,6 +57,28 @@ class Teamleader(object):
             raise InvalidInputError('Invalid argument: ' + repr(arg))
 
         return arg or t()
+
+    @staticmethod
+    def _check_country(country):
+        if country is not None:
+            try:
+                if cmp(pkg_resources.get_distribution('pycountry').version, '16.10.23rc1') < 0:
+                    pycountry.countries.get(alpha2=country.upper())
+                else:
+                    pycountry.countries.get(alpha_2=country.upper())
+            except:
+                raise InvalidInputError("Invalid contents of argument country.")
+
+    @staticmethod
+    def _check_language(language):
+        if language is not None:
+            try:
+                if cmp(pkg_resources.get_distribution('pycountry').version, '16.10.23rc1') < 0:
+                    pycountry.languages.get(iso639_1_code=language.lower())
+                else:
+                    pycountry.languages.get(alpha_2=language.lower())
+            except:
+                raise InvalidInputError("Invalid contents of argument language.")
 
     def get_users(self, show_inactive_users=False):
         """Getting all users.
@@ -157,17 +180,9 @@ class Teamleader(object):
         tags = self._validate_type(tags, list)
         custom_fields = self._validate_type(custom_fields, dict)
 
-        if country is not None:
-            try:
-                pycountry.countries.get(alpha2=country.upper())
-            except:
-                raise InvalidInputError("Invalid contents of argument country.")
+        self._check_country(country)
 
-        if language is not None:
-            try:
-                pycountry.languages.get(iso639_1_code=language.lower())
-            except:
-                raise InvalidInputError("Invalid contents of argument language.")
+        self._check_language(language)
 
         if date_of_birth is not None and type(date_of_birth) != datetime.date:
             raise InvalidInputError("Invalid contents of argument date_of_birth.")
@@ -236,17 +251,9 @@ class Teamleader(object):
         del_tags = self._validate_type(del_tags, list)
         custom_fields = self._validate_type(custom_fields, dict)
 
-        if country is not None:
-            try:
-                pycountry.countries.get(alpha2=country.upper())
-            except:
-                raise InvalidInputError("Invalid contents of argument country.")
+        self._check_country(country)
 
-        if language is not None:
-            try:
-                pycountry.languages.get(iso639_1_code=language.lower())
-            except:
-                raise InvalidInputError("Invalid contents of argument language.")
+        self._check_language(language)
 
         if date_of_birth is not None and type(date_of_birth) != datetime.date:
             raise InvalidInputError("Invalid contents of argument date_of_birth.")
@@ -409,17 +416,9 @@ class Teamleader(object):
         tags = self._validate_type(tags, list)
         custom_fields = self._validate_type(custom_fields, dict)
 
-        if country is not None:
-            try:
-                pycountry.countries.get(alpha2=country.upper())
-            except:
-                raise InvalidInputError("Invalid contents of argument country.")
+        self._check_country(country)
 
-        if language is not None:
-            try:
-                pycountry.languages.get(iso639_1_code=language.lower())
-            except:
-                raise InvalidInputError("Invalid contents of argument language.")
+        self._check_language(language)
 
         if payment_term is not None:
             if payment_term not in ['0D', '7D', '10D', '15D', '21D', '30D', '45D', '60D', '30DEM', '60DEM', '90DEM']:
@@ -481,17 +480,9 @@ class Teamleader(object):
         del_tags = self._validate_type(del_tags, list)
         custom_fields = self._validate_type(custom_fields, dict)
 
-        if country is not None:
-            try:
-                pycountry.countries.get(alpha2=country.upper())
-            except:
-                raise InvalidInputError("Invalid contents of argument country.")
+        self._check_country(country)
 
-        if language is not None:
-            try:
-                pycountry.languages.get(iso639_1_code=language.lower())
-            except:
-                raise InvalidInputError("Invalid contents of argument language.")
+        self._check_language(language)
 
         if payment_term is not None:
             if payment_term not in ['0D', '7D', '10D', '15D', '21D', '30D', '45D', '60D', '30DEM', '60DEM', '90DEM']:
@@ -581,11 +572,7 @@ class Teamleader(object):
             within a certain country.
         """
 
-        if country is not None:
-            try:
-                pycountry.countries.get(alpha2=country.upper())
-            except:
-                raise InvalidInputError("Invalid contents of argument country.")
+        self._check_country(country)
 
         return [d['name'] for d in self._request('getBusinessTypes', {'country': country})]
 

--- a/teamleader/api.py
+++ b/teamleader/api.py
@@ -188,9 +188,9 @@ class Teamleader(object):
             raise InvalidInputError("Invalid contents of argument date_of_birth.")
 
         # convert data elements that need conversion
-        data['add_tag_by_string'] = ','.join(data.pop('tags'))
+        data['add_tag_by_string'] = ','.join(data.pop('tags', []))
 
-        for custom_field_id, custom_field_value in data.pop('custom_fields').items():
+        for custom_field_id, custom_field_value in data.pop('custom_fields', {}).items():
             data['custom_field_' + str(custom_field_id)] = custom_field_value
 
         if date_of_birth is not None:
@@ -259,10 +259,10 @@ class Teamleader(object):
             raise InvalidInputError("Invalid contents of argument date_of_birth.")
 
         # convert data elements that need conversion
-        data['add_tag_by_string'] = ','.join(data.pop('tags'))
-        data['remove_tag_by_string'] = ','.join(data.pop('del_tags'))
+        data['add_tag_by_string'] = ','.join(data.pop('tags', []))
+        data['remove_tag_by_string'] = ','.join(data.pop('del_tags', []))
 
-        for custom_field_id, custom_field_value in data.pop('custom_fields').items():
+        for custom_field_id, custom_field_value in data.pop('custom_fields', {}).items():
             data['custom_field_' + str(custom_field_id)] = custom_field_value
 
         if date_of_birth is not None:
@@ -425,9 +425,9 @@ class Teamleader(object):
                 raise InvalidInputError("Invalid contents of argument payment_term.")
 
         # convert data elements that need conversion
-        data['add_tag_by_string'] = ','.join(data.pop('tags'))
+        data['add_tag_by_string'] = ','.join(data.pop('tags', []))
 
-        for custom_field_id, custom_field_value in data.pop('custom_fields').items():
+        for custom_field_id, custom_field_value in data.pop('custom_fields', {}).items():
             data['custom_field_' + str(custom_field_id)] = custom_field_value
 
         data['automerge_by_name'] = int(automerge_by_name)
@@ -489,10 +489,10 @@ class Teamleader(object):
                 raise InvalidInputError("Invalid contents of argument payment_term.")
 
         # convert data elements that need conversion
-        data['add_tag_by_string'] = ','.join(data.pop('tags'))
-        data['remove_tag_by_string'] = ','.join(data.pop('del_tags'))
+        data['add_tag_by_string'] = ','.join(data.pop('tags', []))
+        data['remove_tag_by_string'] = ','.join(data.pop('del_tags', []))
 
-        for custom_field_id, custom_field_value in data.pop('custom_fields').items():
+        for custom_field_id, custom_field_value in data.pop('custom_fields', {}).items():
             data['custom_field_' + str(custom_field_id)] = custom_field_value
 
         self._request('updateCompany', data)


### PR DESCRIPTION
16.10.23rc1 (2016-10-23)

https://pypi.python.org/pypi/pycountry

This is a major change. The upstream packages have been revamped from the former XML databases to use JSON. They adapted their schemata a bit and thus made some of the structures in pycountry superfluous (yay!). Memory usage went down when all databases are loaded (32.7 MiB down from 83.6 MiB) and performance has gone up (not measured scientifically, but it’s noticable when loading the DBs in an interactive session).

To mark this major change, I’m also switch from the existing (not useful) SemVer-based version numbers to CalVer-based numbers using YY.MM.DD.micro as the pattern.

To avoid adding more complexity I have removed code that really only was necessary because of the complexity of using the XML databases.

Here’s what you need to know:

I updated to iso-codes 3.70 which is a lot fresher than the last release.

Attribute names have changed. There is no longer a mapping going on between the sources and the object attributes. Take a look at the JSON files (or inspect the objects) to see which fields are supported.

You can also inspect the automatically build indexes (db.indices) to see all keys in a database. Not every object supports every attribute - this depends on the quality of the data from pkg-isocodes.

Attribute names are more coherent now, too. Note that “alpha2”, “alpha4”, etc. are now using an underscore as that’s the pattern in the upstream packages. So it’s “alpha_2” now.

HistoricCountries no longer includes countries that still exist. I removed the computed fields that were meant to make it easy to filter.